### PR TITLE
refactor: Update comments, seconds -> milliseconds (#1)

### DIFF
--- a/src/assets/scripts/client/engine/TimeKeeper.js
+++ b/src/assets/scripts/client/engine/TimeKeeper.js
@@ -51,7 +51,7 @@ class TimeKeeper {
         this._elapsedFrameCount = 0;
 
         /**
-         * Time difference in seconds between the `#lastFrame` and `#_frameStartTimestamp`
+         * Time difference in milliseconds between the `#lastFrame` and `#_frameStartTimestamp`
          *
          * **This is the most important value of this class.**
          *
@@ -438,7 +438,7 @@ class TimeKeeper {
      *
      * @for TimeKeeper
      * @method _calculateNextDelatTime
-     * @param currentTime {number} current time in seconds
+     * @param currentTime {number} current time in milliseconds
      * @private
      */
     _calculateNextDeltaTime(currentTime) {


### PR DESCRIPTION
This PR only changes two comments. Nothing else was needed.

Worth noting is that `_calculateNextDeltaTime()` is the value `_frameDeltaTime` (the most important value in the class) is assigned. With the changes in #3, `_frameDeltaTime` should now be 10x its old value.

#1