### PR TITLE
refactor: Check references for assigned TimeKeeper references (#2)

### DIFF
--- a/src/assets/scripts/client/aircraft/AircraftConflict.js
+++ b/src/assets/scripts/client/aircraft/AircraftConflict.js
@@ -126,8 +126,8 @@ export default class AircraftConflict {
 
         // TODO: replace magic numbers with enum
         // Ignore aircraft in the first minute of their flight
-        if (gameTime - this.aircraft[0].takeoffTime < 60 ||
-            gameTime - this.aircraft[1].takeoffTime < 60) {
+        if (gameTime - this.aircraft[0].takeoffTime < 60000 ||
+            gameTime - this.aircraft[1].takeoffTime < 60000) {
             return;
         }
 

--- a/src/assets/scripts/client/aircraft/AircraftConflict.js
+++ b/src/assets/scripts/client/aircraft/AircraftConflict.js
@@ -11,6 +11,7 @@ import { vlen, vsub, vturn } from '../math/vector';
 import { degreesToRadians } from '../utilities/unitConverters';
 import { SEPARATION } from '../constants/aircraftConstants';
 import { EVENT } from '../constants/eventNames';
+import { TIME } from '../constants/globalConstants';
 
 /**
  * Details about aircraft in close proximity in relation to 'the rules'
@@ -126,8 +127,8 @@ export default class AircraftConflict {
 
         // TODO: replace magic numbers with enum
         // Ignore aircraft in the first minute of their flight
-        if (gameTime - this.aircraft[0].takeoffTime < 60000 ||
-            gameTime - this.aircraft[1].takeoffTime < 60000) {
+        if (gameTime - this.aircraft[0].takeoffTime < ONE_MINUTE_IN_MILLISECONDS ||
+            gameTime - this.aircraft[1].takeoffTime < ONE_MINUTE_IN_MILLISECONDS) {
             return;
         }
 

--- a/src/assets/scripts/client/aircraft/AircraftConflict.js
+++ b/src/assets/scripts/client/aircraft/AircraftConflict.js
@@ -127,8 +127,8 @@ export default class AircraftConflict {
 
         // TODO: replace magic numbers with enum
         // Ignore aircraft in the first minute of their flight
-        if (gameTime - this.aircraft[0].takeoffTime < ONE_MINUTE_IN_MILLISECONDS ||
-            gameTime - this.aircraft[1].takeoffTime < ONE_MINUTE_IN_MILLISECONDS) {
+        if (gameTime - this.aircraft[0].takeoffTime < TIME.ONE_MINUTE_IN_MILLISECONDS ||
+            gameTime - this.aircraft[1].takeoffTime < TIME.ONE_MINUTE_IN_MILLISECONDS) {
             return;
         }
 

--- a/src/assets/scripts/client/aircraft/AircraftModel.js
+++ b/src/assets/scripts/client/aircraft/AircraftModel.js
@@ -2267,7 +2267,7 @@ export default class AircraftModel {
             return;
         }
 
-        const secondsElapsed = TimeKeeper.getDeltaTimeForGameStateAndTimewarp();
+        const secondsElapsed = TimeKeeper.getDeltaTimeForGameStateAndTimewarp() * TIME.ONE_MILLISECOND_IN_SECONDS;
         const angle_diff = angle_offset(this.target.heading, this.heading);
         const angle_change = PERFORMANCE.TURN_RATE * secondsElapsed;
 

--- a/src/assets/scripts/client/aircraft/AircraftModel.js
+++ b/src/assets/scripts/client/aircraft/AircraftModel.js
@@ -342,14 +342,14 @@ export default class AircraftModel {
 
         /**
          * Time spent taxiing to the runway. *NOTE* this should be INCREASED
-         * to around 60 once the taxi vs LUAW issue is resolved (#406)
+         * to around 60000 once the taxi vs LUAW issue is resolved (#406)
          *
          * @for AircraftModel
          * @property taxi_time
          * @type {number}
-         * @default 3
+         * @default 3000
          */
-        this.taxi_time = 3;
+        this.taxi_time = 3000;
 
         /**
          * Either IFR or VFR (Instrument/Visual Flight Rules)
@@ -1879,6 +1879,7 @@ export default class AircraftModel {
         const offset = getOffset(this, waypointRelativePosition, inboundHeading);
         const holdLegDurationInMinutes = holdParameters.legLength.replace('min', '');
         const holdLegDurationInSeconds = holdLegDurationInMinutes * TIME.ONE_MINUTE_IN_SECONDS;
+        const holdLegDurationInMilliSeconds = holdLegDurationInSeconds * TIME.ONE_SECOND_IN_MILLISECONDS;
         const gameTime = TimeKeeper.accumulatedDeltaTime;
         const isPastFix = offset[1] < 1 && offset[2] < 2;
         const isTimerSet = holdParameters.timer !== INVALID_NUMBER;
@@ -1895,7 +1896,7 @@ export default class AircraftModel {
         let nextTargetHeading = outboundHeading;
 
         if (this.heading === outboundHeading && !isTimerSet) {
-            currentWaypoint.setHoldTimer(gameTime + holdLegDurationInSeconds);
+            currentWaypoint.setHoldTimer(gameTime + holdLegDurationInMilliSeconds);
         }
 
         if (isTimerExpired) {

--- a/src/assets/scripts/client/aircraft/AircraftModel.js
+++ b/src/assets/scripts/client/aircraft/AircraftModel.js
@@ -2325,8 +2325,8 @@ export default class AircraftModel {
             descentRate = this.model.rate.descent;
         }
 
-        const feetPerSecond = descentRate * TIME.ONE_SECOND_IN_MINUTES;
-        const feetDescended = feetPerSecond * TimeKeeper.getDeltaTimeForGameStateAndTimewarp();
+        const feetPerMilliSecond = descentRate * TIME.ONE_MILLISECOND_IN_MINUTES;
+        const feetDescended = feetPerMilliSecond * TimeKeeper.getDeltaTimeForGameStateAndTimewarp();
 
         if (abs(altitude_diff) < feetDescended) {
             this.altitude = this.target.altitude;

--- a/src/assets/scripts/client/aircraft/AircraftModel.js
+++ b/src/assets/scripts/client/aircraft/AircraftModel.js
@@ -2207,7 +2207,7 @@ export default class AircraftModel {
 
         if (this.hit) {
             // 90fps fall rate?...
-            this.altitude -= 90 * TimeKeeper.getDeltaTimeForGameStateAndTimewarp();
+            this.altitude -= 0.09 * TimeKeeper.getDeltaTimeForGameStateAndTimewarp();
             this.speed *= 0.99;
 
             return;
@@ -2227,7 +2227,7 @@ export default class AircraftModel {
         // const nextHistoricalPosition = [
         //     this.positionModel.relativePosition[0],
         //     this.positionModel.relativePosition[1],
-        //     offsetGameTime
+        //     offsetGameTime //note that we might need to accomodate for change in time unit (seconds -> milliseconds)
         // ];
 
         // TODO: whats the difference here between the if and else blocks? why are we looking for a 0 length?
@@ -2240,7 +2240,7 @@ export default class AircraftModel {
                 offsetGameTime
             ]);
             // TODO: this can be abstracted
-        } else if (abs(offsetGameTime - this.relativePositionHistory[this.relativePositionHistory.length - 1][2]) > 4 / GameController.game_speedup()) {
+        } else if (abs(offsetGameTime - this.relativePositionHistory[this.relativePositionHistory.length - 1][2]) > 4000 / GameController.game_speedup()) {
             this.relativePositionHistory.push([
                 this.positionModel.relativePosition[0],
                 this.positionModel.relativePosition[1],

--- a/src/assets/scripts/client/aircraft/FlightManagementSystem/WaypointModel.js
+++ b/src/assets/scripts/client/aircraft/FlightManagementSystem/WaypointModel.js
@@ -507,7 +507,7 @@ export default class WaypointModel {
      *
      * @for WaypointModel
      * @method setHoldTimer
-     * @param expirationTime {number} game time (seconds) when the timer should "expire"
+     * @param expirationTime {number} game time (milliseconds) when the timer should "expire"
      */
     setHoldTimer(expirationTime) {
         if (typeof expirationTime !== 'number') {

--- a/src/assets/scripts/client/constants/aircraftConstants.js
+++ b/src/assets/scripts/client/constants/aircraftConstants.js
@@ -223,13 +223,13 @@ export const PERFORMANCE = {
     TAKEOFF_TURN_ALTITUDE: 400,
 
     /**
-     * Rate of turn, in radians per second
+     * Rate of turn, in radians per second //Kept per second unit since that is standard
      *
      * @property TURN_RATE
      * @type {number}
      * @final
      */
-    TURN_RATE: 0.0523598776,    // 3 degrees
+    TURN_RATE: 0.0523598776 ,    // 3 degrees
 
     /**
      * Proportion of the maximum capable descent rate that aircraft will use by default

--- a/src/assets/scripts/client/constants/aircraftConstants.js
+++ b/src/assets/scripts/client/constants/aircraftConstants.js
@@ -229,7 +229,7 @@ export const PERFORMANCE = {
      * @type {number}
      * @final
      */
-    TURN_RATE: 0.0523598776 ,    // 3 degrees
+    TURN_RATE: 0.0523598776,    // 3 degrees
 
     /**
      * Proportion of the maximum capable descent rate that aircraft will use by default

--- a/src/assets/scripts/client/engine/TimeKeeper.js
+++ b/src/assets/scripts/client/engine/TimeKeeper.js
@@ -471,7 +471,7 @@ class TimeKeeper {
 
     /**
      * Boolean abstraction used to determine if this frame is being calculated after returning
-     * from pause, which is assumed when `#_frameDeltaTime` is greater than `1` and
+     * from pause, which is assumed when `#_frameDeltaTime` is greater than `1` second (1000ms) and
      * `#_simulationRate` is `1`. And this is not part of a future track calculation, when
      * `#_futureTrackDeltaTimeCache` is `-1`.
      *
@@ -480,7 +480,7 @@ class TimeKeeper {
      * @return {boolean}
      */
     _isReturningFromPauseAndNotFutureTrack() {
-        return this.deltaTime >= 1 && this._simulationRate === 1 && this._futureTrackDeltaTimeCache === -1;
+        return this.deltaTime >= 1000 && this._simulationRate === 1 && this._futureTrackDeltaTimeCache === -1;
     }
 }
 

--- a/src/assets/scripts/client/engine/TimeKeeper.js
+++ b/src/assets/scripts/client/engine/TimeKeeper.js
@@ -471,7 +471,7 @@ class TimeKeeper {
 
     /**
      * Boolean abstraction used to determine if this frame is being calculated after returning
-     * from pause, which is assumed when `#_frameDeltaTime` is greater than `1` second (1000ms) and
+     * from pause, which is assumed when `#_frameDeltaTime` is greater than `1` and
      * `#_simulationRate` is `1`. And this is not part of a future track calculation, when
      * `#_futureTrackDeltaTimeCache` is `-1`.
      *
@@ -480,7 +480,7 @@ class TimeKeeper {
      * @return {boolean}
      */
     _isReturningFromPauseAndNotFutureTrack() {
-        return this.deltaTime >= 1000 && this._simulationRate === 1 && this._futureTrackDeltaTimeCache === -1;
+        return this.deltaTime >= 1 && this._simulationRate === 1 && this._futureTrackDeltaTimeCache === -1;
     }
 }
 

--- a/src/assets/scripts/client/game/GameController.js
+++ b/src/assets/scripts/client/game/GameController.js
@@ -368,7 +368,7 @@ class GameController {
      * @for GameController
      * @method game_timeout
      * @param func {function} called when timeout is triggered
-     * @param delay {number} in seconds
+     * @param delay {number} in milliseconds
      * @param that
      * @param data
      * @return {array} gameTimeout

--- a/src/assets/scripts/client/ui/UiController.js
+++ b/src/assets/scripts/client/ui/UiController.js
@@ -368,7 +368,7 @@ class UiController {
             setTimeout(() => {
                 uiLogView.remove();
             }, 10000);
-        }, 3, window, html);
+        }, 3000, window, html);
     }
 
     /**


### PR DESCRIPTION
Changes from seconds to milliseconds in relevant places (think I found all 2nd/3rd hand references as well).

Kept deegre per second due to standard unit (Hz)

Fixes partly #2
