### PR TITLE
Refactor: Add copy method for base classes(#7)

### DIFF
--- a/src/assets/scripts/client/base/BaseCollection.js
+++ b/src/assets/scripts/client/base/BaseCollection.js
@@ -1,4 +1,5 @@
 import _uniqueId from 'lodash/uniqueId';
+import BaseModel from './BaseModel';
 
 /**
  * Base class from which a collection type class can inherit from.
@@ -73,4 +74,22 @@ export default class BaseCollection {
     // addItems()
     // addItem()
     // removeItem()
+
+    /**
+     * This will copy the the basemodelobject and return it
+     * @returns a copy of the object.
+     */
+    copy() {
+        const copy = this;
+        for (const attr in this) {  
+            // Handle Array
+            if (this[attr] instanceof BaseModel) {
+                copy[attr] = this[attr].copy();
+            }
+            else{
+                copy[attr] = this[attr];
+            }            
+        }   
+        return copy;
+    }
 }

--- a/src/assets/scripts/client/base/BaseModel.js
+++ b/src/assets/scripts/client/base/BaseModel.js
@@ -65,4 +65,21 @@ export default class BaseModel {
         // Default option since it is an optional parameter
         return `${modelName}-`;
     }
+
+    /**
+     * This will copy the the basemodelobject and return it
+     * @returns a copy of the object.
+     */
+    copy() {
+        const copy = this;
+        for (const attr in this) {  
+            if (this[attr] instanceof BaseModel) {
+                copy[attr] = this[attr].copy();
+            }
+            else{
+                copy[attr] = this[attr];
+            } 
+        }
+        return copy;
+    }
 }

--- a/test/airline/AirlineCollection.spec.js
+++ b/test/airline/AirlineCollection.spec.js
@@ -50,6 +50,15 @@ ava('.findAirlineById() returns an AirlineModel when supplied an airlineId mixed
     t.true(result.icao === 'ual');
 });
 
+ava('.copy for AirlineCollection', (t) => {
+    const collection = new AirlineCollection(AIRLINE_DEFINITION_LIST_MOCK);
+    const copy = collection.copy();
+    const result = copy.findAirlineById('uAl');
+
+    t.true(result instanceof AirlineModel);
+    t.true(result.icao === 'ual');
+});
+
 ava('.findAirlineById() returns an AirlineModel when supplied an airlineId with fleet', (t) => {
     const collection = new AirlineCollection(AIRLINE_DEFINITION_LIST_MOCK);
     const result = collection.findAirlineById('ual/long');

--- a/test/airport/AirspaceModel.spec.js
+++ b/test/airport/AirspaceModel.spec.js
@@ -37,3 +37,14 @@ ava('removes last element in poly array if it is the same as the first element',
     t.false(model.poly.length === AIRSPACE_MOCK_WITH_CLOSING_ENTRY.poly.length);
     t.true(model.poly.length === AIRSPACE_MOCK_WITH_CLOSING_ENTRY.poly.length - 1);
 });
+
+
+ava('.copy an AirspaceModel', t => {
+    const model = new AirspaceModel(AIRSPACE_MOCK, airportPositionFixtureKSFO, magneticNorth);
+    const copy = model.copy();
+    t.false(typeof copy._id === 'undefined');
+    t.true(copy.floor === (AIRSPACE_MOCK.floor * 100));
+    t.true(copy.ceiling === (AIRSPACE_MOCK.ceiling * 100));
+    t.true(copy.airspace_class === AIRSPACE_MOCK.airspace_class);
+    t.true(copy.poly.length === AIRSPACE_MOCK.poly.length);
+});

--- a/test/base/BaseCollection.spec.js
+++ b/test/base/BaseCollection.spec.js
@@ -35,3 +35,11 @@ ava('.destroy() does not throw when called from and extending class', t => {
 
     t.notThrows(() => collection.destroy());
 });
+
+ava('.copy is called for a created object', t => {
+    const result = new BaseCollection();
+    const copy = result.copy();
+    t.true(_isString(copy._id));
+    t.true(_isArray(copy._items));
+    t.true(copy.length === 0);
+});

--- a/test/base/BaseModel.spec.js
+++ b/test/base/BaseModel.spec.js
@@ -54,3 +54,9 @@ ava('.reset() does not throw when called from and extending class', t => {
 
     t.notThrows(() => model.reset());
 });
+
+ava('.copy() a model with id modelname', (t) => {
+    const model = new BaseModel('modelName');
+    const cop = model.copy();
+    t.true(cop._id.indexOf('modelName') !== -1);
+});


### PR DESCRIPTION
What does this PR change ?
This adds copy method for BaseModel and BaseCollection.
Also included testcase for BaseModel, BaseCollection and their respective extended classes AirSpacemodel(inherit from Basemodel) and Airlinecollection(inherit from BaseCollection)
What issue(s) does this PR fix ?
fixes #7 