### PR TITLE
refactor: Change deltaTime() to return max 100'000 milliseconds (#1)

### DIFF
--- a/src/assets/scripts/client/engine/TimeKeeper.js
+++ b/src/assets/scripts/client/engine/TimeKeeper.js
@@ -227,7 +227,7 @@ class TimeKeeper {
     get deltaTime() {
         const deltaTimeOffsetBySimulationRate = this._frameDeltaTime * this._simulationRate;
 
-        return Math.min(deltaTimeOffsetBySimulationRate, 100);
+        return Math.min(deltaTimeOffsetBySimulationRate, 100 * TIME.ONE_SECOND_IN_MILLISECONDS);
     }
 
     /**


### PR DESCRIPTION
The purpose of this pull request is to change the implementation of `deltaTime()`.

#1 
